### PR TITLE
redis : fixed ip version indistinguishability

### DIFF
--- a/example_config.yaml
+++ b/example_config.yaml
@@ -27,7 +27,7 @@ chihaya:
       max_numwant: 100
       #    type: redis 
       #    config:
-      #      key_prefix: nm 
+      #      key_prefix: "nm:"
       #      instance: 0
       #      max_numwant: 100
       #      host: 127.0.0.1


### PR DESCRIPTION
Added a pseudo decorator to seeder and leecher prefixes to distinguish between ip6 and ip4 peers.